### PR TITLE
helm:bugfix - added auth ldap env vars and fixed nindent error

### DIFF
--- a/deployments/helm/horusec-platform/templates/deployments/auth.yaml
+++ b/deployments/helm/horusec-platform/templates/deployments/auth.yaml
@@ -106,9 +106,37 @@ spec:
           - name: HORUSEC_KEYCLOAK_OTP
             value: {{ .Values.global.keycloak.otp | quote }}
           {{- end }}
+          {{- if eq .Values.components.auth.type "ldap" }}
+          - name: HORUSEC_LDAP_HOST
+            value: {{ required "A valid global.ldap.host is required!" .Values.global.ldap.host | quote }}
+          - name: HORUSEC_LDAP_BASE
+            valueFrom:
+              secretKeyRef:
+              {{- toYaml .Values.global.ldap.base.secretKeyRef | nindent 16 }}
+          - name: HORUSEC_LDAP_PORT
+            value: {{ required "A valid global.ldap.port is required!" .Values.global.ldap.port | quote }}
+          - name: HORUSEC_LDAP_USESSL
+            value: {{ .Values.global.ldap.ssl | quote }}
+          - name: HORUSEC_LDAP_SKIP_TLS
+            value: {{ .Values.global.ldap.tls | quote }}
+          - name: HORUSEC_LDAP_INSECURE_SKIP_VERIFY
+            value: {{ .Values.global.ldap.skipVerify | quote }}
+          - name: HORUSEC_LDAP_BINDDN
+            valueFrom:
+              secretKeyRef:
+              {{- toYaml .Values.global.ldap.bindDn.secretKeyRef | nindent 16 }}
+          - name: HORUSEC_LDAP_BINDPASSWORD
+            valueFrom:
+              secretKeyRef:
+              {{- toYaml .Values.global.ldap.bindPassword.secretKeyRef | nindent 16 }}
+          - name: HORUSEC_LDAP_USERFILTER
+            value: {{ .Values.global.ldap.userFilter | quote }}
+          - name: HORUSEC_LDAP_ADMIN_GROUP
+            value: {{ .Values.global.ldap.adminGroup | quote }}
+          {{- end }}
           {{- if .Values.components.auth.extraEnv }}
           # Extra environment variables
-          {{- toYaml .Values.components.auth.extraEnv | nindent 12 }}
+          {{- toYaml .Values.components.auth.extraEnv | nindent 10 }}
           {{- end }}
           image: "{{ template "auth.image" . }}"
           imagePullPolicy: {{ .Values.components.auth.container.image.pullPolicy | quote }}

--- a/deployments/helm/horusec-platform/values.yaml
+++ b/deployments/helm/horusec-platform/values.yaml
@@ -404,3 +404,23 @@ global:
     certManager: true
     annotations: {}
       # kubernetes.io/ingress.class: "nginx"
+  ldap:
+    base:
+      secretKeyRef:
+        key: base 
+        name: ldap 
+    host: ""
+    port: ""
+    ssl: false
+    tls: true
+    skipVerify: true
+    bindDn:
+      secretKeyRef:
+        key: bind-dn 
+        name: ldap 
+    bindPassword:
+      secretKeyRef:
+        key: bind-password 
+        name: ldap
+    userFilter: "(sAMAccountName=%s)"
+    adminGroup: ""


### PR DESCRIPTION
Signed-off-by: Nathan Martins <nathan.martins@zup.com.br>

<!--
Customized from the template (https://github.com/docker/cli/blob/master/.github/PULL_REQUEST_TEMPLATE.md)

Please make sure you've read and understood our contributing guidelines;
https://github.com/ZupIT/horusec-platform/blob/master/CONTRIBUTING.md

Please provide the following information:
-->

**- What I did**
- Added missing ldap envs in auth helm files, it only be used if the auth type is ldap, otherwise will be ignored.
- Fixed error with auth extra env nindent. 

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
