### PR TITLE
hotfix:e2e - Change e2e tests to user keycloak in web hosted

### DIFF
--- a/.github/workflows/e2e-pipeline.yml
+++ b/.github/workflows/e2e-pipeline.yml
@@ -12,54 +12,54 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Tests e2e
-on:
-  pull_request:
-    branches:
-      - main
-  push:
-    branches:
-      - main
-jobs:
-  e2e-auth-horusec:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up nodejs
-        uses: actions/setup-node@v2
-        with:
-          node-version: "12"
-        id: node
-      - uses: actions/checkout@v2
-      - name: Run e2e tests
-        env:
-          NODE_TLS_REJECT_UNAUTHORIZED: 0
-        run: |
-          cd ./e2e/cypress
-          make test-e2e-auth-horusec-without-application-admin
-      - name: Upload cypress videos
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-videos
-          path: e2e/cypress/src/videos
-  e2e-auth-keycloak:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up nodejs
-        uses: actions/setup-node@v2
-        with:
-          node-version: "12"
-        id: node
-      - uses: actions/checkout@v2
-      - name: Run e2e tests
-        env:
-          NODE_TLS_REJECT_UNAUTHORIZED: 0
-        run: |
-          cd ./e2e/cypress
-          make test-e2e-auth-keycloak-without-application-admin
-      - name: Upload cypress videos
-        uses: actions/upload-artifact@v2
-        if: failure()
-        with:
-          name: cypress-videos
-          path: e2e/cypress/src/videos
+# name: Tests e2e
+# on:
+#   pull_request:
+#     branches:
+#       - main
+#   push:
+#     branches:
+#       - main
+# jobs:
+#   e2e-auth-horusec:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Set up nodejs
+#         uses: actions/setup-node@v2
+#         with:
+#           node-version: "12"
+#         id: node
+#       - uses: actions/checkout@v2
+#       - name: Run e2e tests
+#         env:
+#           NODE_TLS_REJECT_UNAUTHORIZED: 0
+#         run: |
+#           cd ./e2e/cypress
+#           make test-e2e-auth-horusec-without-application-admin
+#       - name: Upload cypress videos
+#         uses: actions/upload-artifact@v2
+#         if: failure()
+#         with:
+#           name: cypress-videos
+#           path: e2e/cypress/src/videos
+#   e2e-auth-keycloak:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Set up nodejs
+#         uses: actions/setup-node@v2
+#         with:
+#           node-version: "12"
+#         id: node
+#       - uses: actions/checkout@v2
+#       - name: Run e2e tests
+#         env:
+#           NODE_TLS_REJECT_UNAUTHORIZED: 0
+#         run: |
+#           cd ./e2e/cypress
+#           make test-e2e-auth-keycloak-without-application-admin
+#       - name: Upload cypress videos
+#         uses: actions/upload-artifact@v2
+#         if: failure()
+#         with:
+#           name: cypress-videos
+#           path: e2e/cypress/src/videos


### PR DESCRIPTION
It is not possible to use Github Actions to run e2e tests, because we need more resources.
Then I commented this workflow and I moved to AWS Codebuild,
until we refactor to a better structure

Signed-off-by: wilian <wilian.silva@zup.com.br>
