### PR TITLE
Fix filters of the vulnerabilities by file

### DIFF
--- a/manager/src/pages/Overview/Vulnerabilities/index.tsx
+++ b/manager/src/pages/Overview/Vulnerabilities/index.tsx
@@ -265,11 +265,7 @@ const Vulnerabilities: React.FC = () => {
     setSelectedFile(vulFile);
 
     vulnerabilitiesService
-      .getVulnerabilitiesOfFile(
-        { workspaceID: workspaceId, repositoryID: vulFile.repositoryID },
-        pagination,
-        vulFile.file
-      )
+      .getVulnerabilitiesOfFile(filters, pagination, vulFile.file)
       .then((result) => {
         let vulnerabilities: Vulnerability[] = result?.data?.content?.data;
         vulnerabilities = applyCurrentUpdatesVulnerabilities(vulnerabilities);


### PR DESCRIPTION
When you update filter of the page of vulnerability by file
not is possible see data because allways filter of the vulnType
is with value "Vulnerability" not changed to other type

Signed-off-by: wilian <wilian.silva@zup.com.br>
